### PR TITLE
Run txns foreal w error states

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -236,44 +236,44 @@ const Home: NextPage = () => {
   }
 
   const createProxy = async (fiat: any, user: string) => {
-    await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
-    // await sendAndWait(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    // await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    await sendAndWait(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
   }
 
   const setUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
-    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    // await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
   }
 
   const unsetUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
-    // await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setFIATAllowance = async (fiat: any) => {
     const token = fiat.getContracts.fiat;
-    await dryRun(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.deltaDebt);
-    // await sendAndWait(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.debt);
+    // await dryRun(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.deltaDebt);
+    await sendAndWait(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.debt);
   }
 
   const unsetFIATAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
-    // await sendAndWait(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await dryRun(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
+    await sendAndWait(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setMonetaDelegate = async (fiat: any) => {
     const { codex, moneta } = fiat.getContracts();
-    await dryRun(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
-    // await sendAndWait(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
+    // await dryRun(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
+    await sendAndWait(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
   }
 
   const unsetMonetaDelegate = async (fiat: any) => {
     const { codex, moneta } = fiat.getContracts();
-    await dryRun(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
-    // await sendAndWait(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
+    // await dryRun(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
+    await sendAndWait(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
   }
 
   const buyCollateralAndModifyDebt = async () => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,17 +198,20 @@ const Home: NextPage = () => {
     try {
       setTransactionData({ action: method, status: 'sent' });
 
-      // OPTIONAL: wait to simulate a real txn
-      await new Promise((resolve) => {
+      // OPTIONAL: resolve with wait to to simulate a real txn
+      // and reject with a fake error to test error states
+      await new Promise((resolve: any, reject: any) => {
         setTimeout(resolve, 200);
+        // setTimeout(reject({message: 'Fake error'}), 200);
       });
 
       const resp = await fiat.dryrun(contract, method, ...args);
       console.log('Dryrun resp: ', resp);
       setTransactionData(initialState.transactionData);
     } catch (e) {
-      console.error('Error: ', e);
+      console.error('Dryrun error: ', e);
       setTransactionData({ ...transactionData, status: 'error' });
+      throw e
     }
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -160,6 +160,7 @@ const Home: NextPage = () => {
       position = getPositionData(positionsData, vault, tokenId, owner);
     }
     const data = { ...modifyPositionData, collateralType, position };
+    formDataStore.setFormDataLoading(true);
     formDataStore.calculateNewPositionData(contextData.fiat, data, null);
     setModifyPositionData(data);
 
@@ -192,7 +193,10 @@ const Home: NextPage = () => {
         ...modifyPositionData, ...data, underlierAllowance, underlierBalance, monetaDelegate, fiatAllowance
       });
     })();
-  }, [connector, contextData, collateralTypesData, positionsData, selectedCollateralTypeId, selectedPositionId, modifyPositionData, formDataStore]);
+
+    // Eslint thinks formDataStore is a dependency, but that will never change. The only true dependency is its the calculateNewPositionData method
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connector, contextData, collateralTypesData, positionsData, selectedCollateralTypeId, selectedPositionId, modifyPositionData, formDataStore.calculateNewPositionData]);
 
   const dryRun = async (fiat: any, action: string, contract: ethers.Contract, method: string, ...args: any[]) => {
     try {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -187,8 +187,9 @@ const Home: NextPage = () => {
         { contract: underlier, method: 'allowance', args: [proxy, vaultEPTActions.address] },
         { contract: underlier, method: 'balanceOf', args: [user] },
         { contract: codex, method: 'delegates', args: [proxy, moneta.address] },
-        { contract: fiat, method: 'allowance', args: [proxy, vaultEPTActions.address] }
+        { contract: fiat, method: 'allowance', args: [user, proxy] }
       ]);
+
       setModifyPositionData({
         ...modifyPositionData, ...data, underlierAllowance, underlierBalance, monetaDelegate, fiatAllowance
       });
@@ -241,14 +242,26 @@ const Home: NextPage = () => {
 
   const setUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
-    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
+    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
   }
 
   const unsetUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
     await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
     // await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+  }
+
+  const setFIATAllowance = async (fiat: any) => {
+    const token = fiat.getContracts.fiat;
+    await dryRun(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.deltaDebt);
+    // await sendAndWait(fiat, 'setFIATAllowance', token, 'approve', contextData.proxies[0], formDataStore.debt);
+  }
+
+  const unsetFIATAllowance = async (fiat: any) => {
+    const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
+    await dryRun(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await sendAndWait(fiat, 'unsetFIATAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setMonetaDelegate = async (fiat: any) => {
@@ -390,15 +403,16 @@ const Home: NextPage = () => {
         modifyPositionData={modifyPositionData}
         redeemCollateralAndModifyDebt={redeemCollateralAndModifyDebt}
         sellCollateralAndModifyDebt={sellCollateralAndModifyDebt}
+        setFIATAllowance={setFIATAllowance}
         setTransactionStatus={(status) =>
           setTransactionData({ ...transactionData, status })
         }
         setMonetaDelegate={setMonetaDelegate}
         setUnderlierAllowance={setUnderlierAllowance}
         transactionData={transactionData}
+        unsetFIATAllowance={unsetFIATAllowance}
         unsetMonetaDelegate={unsetMonetaDelegate}
         unsetUnderlierAllowance={unsetUnderlierAllowance}
-        onSendTransaction={(action) => setTransactionData({ ...transactionData, action })}
         open={(!!selectedPositionId)}
         onClose={() => {
           setSelectedPositionId(initialState.selectedCollateralTypeId);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -194,17 +194,17 @@ const Home: NextPage = () => {
     })();
   }, [connector, contextData, collateralTypesData, positionsData, selectedCollateralTypeId, selectedPositionId, modifyPositionData, formDataStore]);
 
-  /*
-   * So basically 2 kinds of errors/loading states
-   * Create proxy 
-   *
-   *
-   */
   const dryRun = async (fiat: any, contract: ethers.Contract, method: string, ...args: any[]) => {
     try {
       setTransactionData({ action: method, status: 'sent' });
+
+      // OPTIONAL: wait to simulate a real txn
+      await new Promise((resolve) => {
+        setTimeout(resolve, 200);
+      });
+
       const resp = await fiat.dryrun(contract, method, ...args);
-      console.log('resp: ', resp);
+      console.log('Dryrun resp: ', resp);
       setTransactionData(initialState.transactionData);
     } catch (e) {
       console.error('Error: ', e);
@@ -225,8 +225,8 @@ const Home: NextPage = () => {
   }
 
   const createProxy = async (fiat: any, user: string) => {
-    // await dryRun(fiat, fiat.getContracts().proxyRegistry, 'deployFor', contextData.user);
-    await sendAndWait(fiat, fiat.getContracts().proxyRegistry, 'deployFor', user);
+    await dryRun(fiat, fiat.getContracts().proxyRegistry, 'deployFor', user);
+    // await sendAndWait(fiat, fiat.getContracts().proxyRegistry, 'deployFor', user);
   }
 
   const setUnderlierAllowance = async (fiat: any) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,8 +198,9 @@ const Home: NextPage = () => {
     try {
       setTransactionData({ action, status: 'sent' });
 
-      // OPTIONAL: resolve with wait to to simulate a real txn
-      // and reject with a fake error to test error states
+      // OPTIONAL:
+      // uncomment setTimeout(resolve(...)) simulate loading state of a real txn
+      // uncomment setTimeout(reject(...)) to simulate a txn error
       await new Promise((resolve: any, reject: any) => {
         setTimeout(resolve, 200);
         // setTimeout(reject({message: 'Fake error'}), 200);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -230,32 +230,32 @@ const Home: NextPage = () => {
   }
 
   const createProxy = async (fiat: any, user: string) => {
-    // await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
-    await sendAndWait(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    // await sendAndWait(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
   }
 
   const setUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    // await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
-    await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
+    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
+    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], modifyPositionFormData.underlier);
   }
 
   const unsetUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    // await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
-    await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setMonetaDelegate = async (fiat: any) => {
     const { codex, moneta } = fiat.getContracts();
-    // await dryRun(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
-    await sendAndWait(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
+    await dryRun(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
+    // await sendAndWait(fiat, 'setMonetaDelegate', codex, 'grantDelegate', moneta.address);
   }
 
   const unsetMonetaDelegate = async (fiat: any) => {
     const { codex, moneta } = fiat.getContracts();
-    // await dryRun(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
-    await sendAndWait(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
+    await dryRun(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
+    // await sendAndWait(fiat, 'unsetMonetaDelegate', codex, 'revokeDelegate', moneta.address);
   }
 
   const buyCollateralAndModifyDebt = async () => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -184,7 +184,7 @@ const Home: NextPage = () => {
       if (!signer || !signer.provider) return;
       const user = await signer.getAddress();
       const [underlierAllowance, underlierBalance, monetaDelegate, fiatAllowance] = await contextData.fiat.multicall([
-        { contract: underlier, method: 'allowance', args: [proxy, vaultEPTActions.address] },
+        { contract: underlier, method: 'allowance', args: [user, proxy] },
         { contract: underlier, method: 'balanceOf', args: [user] },
         { contract: codex, method: 'delegates', args: [proxy, moneta.address] },
         { contract: fiat, method: 'allowance', args: [user, proxy] }
@@ -242,14 +242,14 @@ const Home: NextPage = () => {
 
   const setUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
-    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    // await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
   }
 
   const unsetUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
-    // await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setFIATAllowance = async (fiat: any) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -207,8 +207,8 @@ const Home: NextPage = () => {
       // uncomment setTimeout(resolve(...)) simulate loading state of a real txn
       // uncomment setTimeout(reject(...)) to simulate a txn error
       await new Promise((resolve: any, reject: any) => {
-        setTimeout(resolve, 200);
-        // setTimeout(reject({message: 'Mock dryrun error, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut convallis luctus lectus vel tempor. Vestibulum porta odio et dui pretium, nec hendrerit ante efficitur. Duis cursus eleifend fringilla.'}), 200);
+        // setTimeout(resolve, 200);
+        setTimeout(reject({message: 'Mock dryrun error, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut convallis luctus lectus vel tempor. Vestibulum porta odio et dui pretium, nec hendrerit ante efficitur. Duis cursus eleifend fringilla.'}), 200);
       });
 
       const resp = await fiat.dryrun(contract, method, ...args);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -208,7 +208,7 @@ const Home: NextPage = () => {
       // uncomment setTimeout(reject(...)) to simulate a txn error
       await new Promise((resolve: any, reject: any) => {
         setTimeout(resolve, 200);
-        // setTimeout(reject({message: 'Fake error'}), 200);
+        // setTimeout(reject({message: 'Mock dryrun error, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut convallis luctus lectus vel tempor. Vestibulum porta odio et dui pretium, nec hendrerit ante efficitur. Duis cursus eleifend fringilla.'}), 200);
       });
 
       const resp = await fiat.dryrun(contract, method, ...args);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -207,8 +207,8 @@ const Home: NextPage = () => {
       // uncomment setTimeout(resolve(...)) simulate loading state of a real txn
       // uncomment setTimeout(reject(...)) to simulate a txn error
       await new Promise((resolve: any, reject: any) => {
-        // setTimeout(resolve, 200);
-        setTimeout(reject({message: 'Mock dryrun error, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut convallis luctus lectus vel tempor. Vestibulum porta odio et dui pretium, nec hendrerit ante efficitur. Duis cursus eleifend fringilla.'}), 200);
+        setTimeout(resolve, 2000);
+        // setTimeout(reject({message: 'Mock dryrun error, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut convallis luctus lectus vel tempor. Vestibulum porta odio et dui pretium, nec hendrerit ante efficitur. Duis cursus eleifend fringilla.'}), 20000);
       });
 
       const resp = await fiat.dryrun(contract, method, ...args);
@@ -242,14 +242,14 @@ const Home: NextPage = () => {
 
   const setUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    // await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
-    await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    await dryRun(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
+    // await sendAndWait(fiat, 'setUnderlierAllowance', token, 'approve', contextData.proxies[0], formDataStore.underlier);
   }
 
   const unsetUnderlierAllowance = async (fiat: any) => {
     const token = fiat.getERC20Contract(modifyPositionData.collateralType.properties.underlierToken);
-    // await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
-    await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    await dryRun(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
+    // await sendAndWait(fiat, 'unsetUnderlierAllowance', token, 'approve', contextData.proxies[0], 0);
   }
 
   const setFIATAllowance = async (fiat: any) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -158,8 +158,8 @@ export const buyCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'buyCollateralAndModifyDebt',
@@ -203,8 +203,8 @@ export const buyCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'buyCollateralAndModifyDebt',
@@ -230,8 +230,8 @@ export const buyCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'buyCollateralAndModifyDebt',
@@ -291,8 +291,8 @@ export const sellCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'sellCollateralAndModifyDebt',
@@ -337,8 +337,8 @@ export const sellCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'sellCollateralAndModifyDebt',
@@ -363,8 +363,8 @@ export const sellCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'sellCollateralAndModifyDebt',
@@ -421,8 +421,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'redeemCollateralAndModifyDebt',
@@ -445,8 +445,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'redeemCollateralAndModifyDebt',
@@ -470,8 +470,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
-        // await contextData.fiat.sendAndWaitViaProxy(
+        // await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'redeemCollateralAndModifyDebt',

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -158,7 +158,7 @@ export const buyCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'buyCollateralAndModifyDebt',
@@ -202,7 +202,7 @@ export const buyCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'buyCollateralAndModifyDebt',
@@ -228,7 +228,7 @@ export const buyCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'buyCollateralAndModifyDebt',
@@ -288,7 +288,7 @@ export const sellCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'sellCollateralAndModifyDebt',
@@ -333,7 +333,7 @@ export const sellCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'sellCollateralAndModifyDebt',
@@ -358,7 +358,7 @@ export const sellCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'sellCollateralAndModifyDebt',
@@ -415,7 +415,7 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'redeemCollateralAndModifyDebt',
@@ -438,7 +438,7 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'redeemCollateralAndModifyDebt',
@@ -462,7 +462,7 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.dryrunViaProxy(
+        await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'redeemCollateralAndModifyDebt',

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -158,7 +158,8 @@ export const buyCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'buyCollateralAndModifyDebt',
@@ -202,7 +203,8 @@ export const buyCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'buyCollateralAndModifyDebt',
@@ -228,7 +230,8 @@ export const buyCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'buyCollateralAndModifyDebt',
@@ -288,7 +291,8 @@ export const sellCollateralAndModifyDebt = async (
       const deadline = Math.round(+new Date() / 1000) + 3600;
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'sellCollateralAndModifyDebt',
@@ -333,7 +337,8 @@ export const sellCollateralAndModifyDebt = async (
       );
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'sellCollateralAndModifyDebt',
@@ -358,7 +363,8 @@ export const sellCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'sellCollateralAndModifyDebt',
@@ -415,7 +421,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultEPTActions,
           'redeemCollateralAndModifyDebt',
@@ -438,7 +445,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFCActions,
           'redeemCollateralAndModifyDebt',
@@ -462,7 +470,8 @@ export const redeemCollateralAndModifyDebt = async (
       }
 
       console.log(
-        await contextData.fiat.sendAndWaitViaProxy(
+        await contextData.fiat.dryrunViaProxy(
+        // await contextData.fiat.sendAndWaitViaProxy(
           contextData.proxies[0],
           vaultFYActions,
           'redeemCollateralAndModifyDebt',

--- a/src/components/CreatePositionModal.tsx
+++ b/src/components/CreatePositionModal.tsx
@@ -302,7 +302,10 @@ const CreatePositionModalBody = (props: CreatePositionModalProps) => {
         <Text size={'0.875rem'}>Approve {underlierSymbol}</Text>
         <Switch
           disabled={props.disableActions || !hasProxy}
-          checked={!formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)}
+          // Next UI Switch `checked` type is wrong, this is necessary
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          checked={() => !formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)}
           onChange={() =>
             !formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)
               ? props.unsetUnderlierAllowance(props.contextData.fiat)
@@ -321,7 +324,10 @@ const CreatePositionModalBody = (props: CreatePositionModalProps) => {
         <Text size={'0.875rem'}>Enable FIAT</Text>
         <Switch
           disabled={props.disableActions || !hasProxy}
-          checked={monetaDelegate ?? false}
+          // Switch type is wrong, this is necessary
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          checked={() => monetaDelegate ?? false}
           onChange={() =>
             !!monetaDelegate
               ? props.unsetMonetaDelegate(props.contextData.fiat)

--- a/src/components/CreatePositionModal.tsx
+++ b/src/components/CreatePositionModal.tsx
@@ -45,7 +45,6 @@ export const CreatePositionModal = (props: CreatePositionModalProps) => {
     <Modal
       preventClose
       closeButton={!props.disableActions}
-      blur
       open={props.open}
       onClose={() => props.onClose()}
     >
@@ -85,7 +84,10 @@ const CreatePositionModalBody = (props: CreatePositionModalProps) => {
   return (
     <>
       <Modal.Header>
-        <Text id='modal-title' size={18}>
+        <Text
+          id='modal-title'
+          size={18}
+        >
           <Text b size={18}>
             Create Position
           </Text>

--- a/src/components/CreatePositionModal.tsx
+++ b/src/components/CreatePositionModal.tsx
@@ -309,7 +309,7 @@ const CreatePositionModalBody = (props: CreatePositionModalProps) => {
           // Next UI Switch `checked` type is wrong, this is necessary
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          checked={() => underlierAllowance?.gte(formDataStore.underlier) ?? false}
+          checked={() => underlierAllowance?.gt(0) && underlierAllowance?.gte(formDataStore.underlier) ?? false}
           onChange={async () => {
             if (!formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)) {
               try {

--- a/src/components/ErrorTooltip.tsx
+++ b/src/components/ErrorTooltip.tsx
@@ -35,13 +35,34 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
             wordWrap: 'break-word',
           }}
         >
-          <Text style={{ wordWrap: 'break-word' }}>{error}</Text>
+          <Text
+            style={{
+              wordWrap: 'break-word',
+            }}
+          >
+            {error}
+          </Text>
         </div>
       }
       placement='bottomEnd'
+      style={{
+        width: '100%',
+        border: '1px solid rgba(250, 43, 57, 0.24)',
+        borderRadius: 'var(--nextui-radii-md)',
+        padding: '.25rem 1rem .25rem 1rem',
+      }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
-        <InfoIcon fill='red' />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          width: '100%',
+        }}
+      >
+        <div>
+          <InfoIcon fill='red' />
+        </div>
         <Text
           color='error'
           style={{

--- a/src/components/ErrorTooltip.tsx
+++ b/src/components/ErrorTooltip.tsx
@@ -60,7 +60,7 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
           width: '100%',
         }}
       >
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
           <InfoIcon fill='red' />
         </div>
         <Text

--- a/src/components/ErrorTooltip.tsx
+++ b/src/components/ErrorTooltip.tsx
@@ -28,6 +28,16 @@ export const InfoIcon = (props: any) => {
 export const ErrorTooltip = ({ error }: { error: string }) => {
   return (
     <Tooltip
+      style={{
+        width: '100%',
+        border: '1px solid rgba(250, 43, 57, 0.24)',
+        borderRadius: 'var(--nextui-radii-md)',
+        padding: '.25rem 1rem .25rem 1rem',
+      }}
+      trigger='hover'
+      css={{
+        zIndex: '999999 !important',
+      }}
       content={
         <div
           style={{
@@ -44,13 +54,6 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
           </Text>
         </div>
       }
-      placement='bottomEnd'
-      style={{
-        width: '100%',
-        border: '1px solid rgba(250, 43, 57, 0.24)',
-        borderRadius: 'var(--nextui-radii-md)',
-        padding: '.25rem 1rem .25rem 1rem',
-      }}
     >
       <div
         style={{
@@ -60,7 +63,12 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
           width: '100%',
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'center' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
           <InfoIcon fill='red' />
         </div>
         <Text

--- a/src/components/ErrorTooltip.tsx
+++ b/src/components/ErrorTooltip.tsx
@@ -30,7 +30,7 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
     <Tooltip
       style={{
         width: '100%',
-        border: '1px solid rgba(250, 43, 57, 0.24)',
+        border: '1px solid var(--nextui-colors-error)',
         borderRadius: 'var(--nextui-radii-md)',
         padding: '.25rem 1rem .25rem 1rem',
       }}
@@ -69,7 +69,7 @@ export const ErrorTooltip = ({ error }: { error: string }) => {
             alignItems: 'center',
           }}
         >
-          <InfoIcon fill='red' />
+          <InfoIcon fill='var(--nextui-colors-error)' />
         </div>
         <Text
           color='error'

--- a/src/components/ErrorTooltip.tsx
+++ b/src/components/ErrorTooltip.tsx
@@ -1,0 +1,60 @@
+// Icon from:
+
+import { Text, Tooltip } from '@nextui-org/react';
+
+// https://icons.radix-ui.com/
+export const InfoIcon = (props: any) => {
+  return (
+    <svg
+      width='15'
+      height='15'
+      viewBox='0 0 15 15'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M7.49991 0.876892C3.84222 0.876892 0.877075 3.84204 0.877075 7.49972C0.877075 11.1574 3.84222 14.1226 7.49991 14.1226C11.1576 14.1226 14.1227 11.1574 14.1227 7.49972C14.1227 3.84204 11.1576 0.876892 7.49991 0.876892ZM1.82707 7.49972C1.82707 4.36671 4.36689 1.82689 7.49991 1.82689C10.6329 1.82689 13.1727 4.36671 13.1727 7.49972C13.1727 10.6327 10.6329 13.1726 7.49991 13.1726C4.36689 13.1726 1.82707 10.6327 1.82707 7.49972ZM8.24992 4.49999C8.24992 4.9142 7.91413 5.24999 7.49992 5.24999C7.08571 5.24999 6.74992 4.9142 6.74992 4.49999C6.74992 4.08577 7.08571 3.74999 7.49992 3.74999C7.91413 3.74999 8.24992 4.08577 8.24992 4.49999ZM6.00003 5.99999H6.50003H7.50003C7.77618 5.99999 8.00003 6.22384 8.00003 6.49999V9.99999H8.50003H9.00003V11H8.50003H7.50003H6.50003H6.00003V9.99999H6.50003H7.00003V6.99999H6.50003H6.00003V5.99999Z'
+        fill={props.fill}
+        fillRule='evenodd'
+        clipRule='evenodd'
+      ></path>
+    </svg>
+  );
+};
+
+// TODO: This shows the error but not the greatest UX
+// We could do a copy to clipboard on click, so they can post errs on discord. Aave does this
+// Actually it looks like sendAndWait errors aren't getting 4byte decoded so maybe that will help?
+// This seems fine for now tho
+export const ErrorTooltip = ({ error }: { error: string }) => {
+  return (
+    <Tooltip
+      content={
+        <div
+          style={{
+            maxWidth: '24rem',
+            wordWrap: 'break-word',
+          }}
+        >
+          <Text style={{ wordWrap: 'break-word' }}>{error}</Text>
+        </div>
+      }
+      placement='bottomEnd'
+    >
+      <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+        <InfoIcon fill='red' />
+        <Text
+          color='error'
+          style={{
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            maxWidth: '40ch',
+            marginLeft: '0.5rem',
+          }}
+        >
+          Error: {error}
+        </Text>
+      </div>
+    </Tooltip>
+  );
+};

--- a/src/components/ModifyPositionModal.tsx
+++ b/src/components/ModifyPositionModal.tsx
@@ -25,13 +25,14 @@ interface ModifyPositionModalProps {
   modifyPositionData: any;
   redeemCollateralAndModifyDebt: () => any;
   sellCollateralAndModifyDebt: () => any;
+  setFIATAllowance: (fiat: any) => any;
   setTransactionStatus: (status: TransactionStatus) => void;
   setMonetaDelegate: (fiat: any) => any;
   setUnderlierAllowance: (fiat: any) => any;
   transactionData: any;
+  unsetFIATAllowance: (fiat: any) => any;
   unsetMonetaDelegate: (fiat: any) => any;
   unsetUnderlierAllowance: (fiat: any) => any;
-  onSendTransaction: (action: string) => void;
   open: boolean;
   onClose: () => void;
 }
@@ -309,9 +310,10 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
             <Text size={'0.875rem'}>Approve {underlierSymbol}</Text>
             <Switch
               disabled={props.disableActions || !hasProxy}
-              checked={
-                !formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)
-              }
+              // Next UI Switch `checked` type is wrong, this is necessary
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              checked={() => !formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)}
               onChange={() => {
                 !formDataStore.underlier.isZero() && underlierAllowance.gte(formDataStore.underlier)
                   ? props.unsetUnderlierAllowance(props.contextData.fiat)
@@ -331,7 +333,10 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
             <Text size={'0.875rem'}>Enable FIAT</Text>
             <Switch
               disabled={props.disableActions || !hasProxy}
-              checked={!!monetaDelegate}
+              // Next UI Switch `checked` type is wrong, this is necessary
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              checked={() => !!monetaDelegate}
               onChange={() =>
                 !!monetaDelegate
                   ? props.unsetMonetaDelegate(props.contextData.fiat)
@@ -353,12 +358,14 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
             <Text size={'0.875rem'}>Approve FIAT</Text>
             <Switch
               disabled={props.disableActions || !hasProxy}
-              checked={!formDataStore.deltaDebt.isZero() && fiatAllowance.gte(formDataStore.deltaDebt)}
-              // TODO: these methods are not implemented
+              // Next UI Switch `checked` type is wrong, this is necessary
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              checked={() => fiatAllowance?.gte(formDataStore.deltaDebt) ?? false}
               onChange={() =>
                 !formDataStore.deltaDebt.isZero() && fiatAllowance.gte(formDataStore.deltaDebt)
-                  ? props.onSendTransaction('unsetFIATAllowance')
-                  : props.onSendTransaction('setFIATAllowance')
+                  ? props.unsetFIATAllowance(props.contextData.fiat)
+                  : props.setFIATAllowance(props.contextData.fiat)
               }
               color='primary'
               icon={

--- a/src/components/ModifyPositionModal.tsx
+++ b/src/components/ModifyPositionModal.tsx
@@ -313,7 +313,7 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
               // Next UI Switch `checked` type is wrong, this is necessary
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
-              checked={() => !formDataStore.underlier.isZero() && underlierAllowance?.gte(formDataStore.underlier)}
+              checked={() => underlierAllowance?.gte(0) && underlierAllowance?.gte(formDataStore.underlier)}
               onChange={() => {
                 !formDataStore.underlier.isZero() && underlierAllowance.gte(formDataStore.underlier)
                   ? props.unsetUnderlierAllowance(props.contextData.fiat)
@@ -361,7 +361,7 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
               // Next UI Switch `checked` type is wrong, this is necessary
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
-              checked={() => fiatAllowance?.gte(formDataStore.deltaDebt) ?? false}
+              checked={() => fiatAllowance?.gt(0) && fiatAllowance?.gte(formDataStore.deltaDebt) ?? false}
               onChange={() =>
                 !formDataStore.deltaDebt.isZero() && fiatAllowance.gte(formDataStore.deltaDebt)
                   ? props.unsetFIATAllowance(props.contextData.fiat)

--- a/src/components/ProxyCard.tsx
+++ b/src/components/ProxyCard.tsx
@@ -1,7 +1,9 @@
 import { Button, Card, Link, Spacer, Text } from '@nextui-org/react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
+import {useState} from 'react';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { useSigner } from 'wagmi';
+import { ErrorTooltip } from './ErrorTooltip';
 
 interface ProxyCardProps {
   createProxy: (fiat: any, user: string) => any;
@@ -15,6 +17,7 @@ interface ProxyCardProps {
 export const ProxyCard = (props: ProxyCardProps) => {
   const { openConnectModal } = useConnectModal();
   const { data: signerData, isFetching: isFetchingSigner } = useSigner();
+  const [error, setError] = useState('');
 
   return (
     <SkeletonTheme baseColor='#202020' highlightColor='#444'>
@@ -43,7 +46,7 @@ export const ProxyCard = (props: ProxyCardProps) => {
                 <>
                   <Spacer y={1} />
                   <Button
-                    onPress={() => {
+                    onPress={async () => {
                       // If no address available, prompt user to connect when they click the button
                       if (!props.user) {
                         if (openConnectModal) {
@@ -51,13 +54,27 @@ export const ProxyCard = (props: ProxyCardProps) => {
                           openConnectModal();
                         }
                       } else {
-                        props.createProxy(props.fiat, props.user)
+                        try {
+                          setError('');
+                          await props.createProxy(props.fiat, props.user)
+                        } catch (e: any) {
+                          setError(e.message);
+                        }
                       }
                     }}
                     disabled={props.disableActions}
                   >
                     Setup a new Proxy account
                   </Button>
+                  { error === ''
+                    ? null
+                    :(
+                      <>
+                        <Spacer y={0.5} />
+                        <ErrorTooltip error={error} />
+                      </>
+                    )
+                  }
                 </>
               )}
             </>

--- a/src/components/ProxyCard.tsx
+++ b/src/components/ProxyCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Link, Spacer, Text } from '@nextui-org/react';
+import { Button, Card, Link, Loading, Spacer, Text } from '@nextui-org/react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import {useState} from 'react';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
@@ -64,7 +64,7 @@ export const ProxyCard = (props: ProxyCardProps) => {
                     }}
                     disabled={props.disableActions}
                   >
-                    Setup a new Proxy account
+                    {props.disableActions ? <Loading /> : 'Setup a new Proxy account'}
                   </Button>
                   { error === ''
                     ? null

--- a/src/components/ProxyCard.tsx
+++ b/src/components/ProxyCard.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Link, Loading, Spacer, Text } from '@nextui-org/react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
-import {useState} from 'react';
+import { useState } from 'react';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { useSigner } from 'wagmi';
 import { ErrorTooltip } from './ErrorTooltip';

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -58,6 +58,7 @@ interface FormActions {
     modifyPositionData: any,
     selectedCollateralTypeId: string | null
   ) => void;
+  setFormDataLoading: (isLoading: boolean) => void;
   calculateNewPositionData: (
     fiat: any,
     modifyPositionData: any,
@@ -221,6 +222,10 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
         modifyPositionData,
         selectedCollateralTypeId
       );
+    },
+
+    setFormDataLoading: (isLoading) => {
+      set(() => ({ formDataLoading: isLoading }));
     },
 
     // Calculates new health factor, collateral, debt, and deltaCollateral as needed


### PR DESCRIPTION
* Adds reusable functions for `dryrun` and `sendAndWait`. For the more complex actions in actions.ts, put `dryrunViaProxy` `sendAndWaitViaProxy` right next to each other for easy switching.
Comment one out, uncomment the other to switch in `index.tsx` and `actions.ts`

* Adds new error component. show truncated msg, hover for full msg

TODO
- [x] Loading signifiers for methods (disable inputs while txn is in flight, while setting approvals switches show loading symbol, while user action is getting confirmed show loading symbol in action button)
- [ ] Custom error for proxy card failure
- [ ] Display errors in modals when txns fail (added a fake promise rejection to dryrun to help test this)
- [ ] Live update when transaction succeeds
- [ ] Error checking on form inputs for when user enters invalid data. Err State 1: FIAT minted would be below the debt floor. Err state 2: slippage / price impact to high (check discord for details)

maybe for a diff ticket?
- [ ] When transaction is sent, add the transaction to the rainbow kit [recent transactions](https://www.rainbowkit.com/docs/recent-transactions)