### PR TITLE
Fix proxy and fiat balance badge height

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -395,7 +395,8 @@ const Home: NextPage = () => {
                 boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
                 '&:hover': {
                   transform: 'scale(1.03)'
-                }
+                },
+                border: 'none',
               }}
             >
               {fiatBalance}

--- a/src/components/ProxyButton.tsx
+++ b/src/components/ProxyButton.tsx
@@ -33,7 +33,8 @@ export const ProxyButton = (props: ProxyCardProps) => {
           boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.1)',
           '&:hover': {
             transform: 'scale(1.03)'
-          }
+          },
+          border: 'none',
         }}      
       >
         <Link


### PR DESCRIPTION
![Screen Shot 2022-11-13 at 9 08 33 PM](https://user-images.githubusercontent.com/100230377/201560467-255c7e12-389f-4cf4-8895-ddf58e94ed16.png)

Removed hidden border that was causing badge height to shrink to fit in parent container.