### PR TITLE
Styling Fixes

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -453,7 +453,7 @@ const Home: NextPage = () => {
         disableActions={disableActions}
         createProxy={createProxy}
       />
-      <Container>
+      <Container lg>
         {
           positionsData === null || positionsData.length === 0
             ? null
@@ -473,7 +473,7 @@ const Home: NextPage = () => {
             )
         }
       </Container>
-      <Container>
+      <Container lg>
         <CollateralTypesTable
           collateralTypesData={collateralTypesData}
           positionsData={positionsData}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,6 +78,7 @@ const Home: NextPage = () => {
     ), shallow
   );
 
+  const [initialPageLoad, setInitialPageLoad] = React.useState<boolean>(true);
   const [setupListeners, setSetupListeners] = React.useState(false);
   const [contextData, setContextData] = React.useState(initialState.contextData);
   const [collateralTypesData, setCollateralTypesData] = React.useState(initialState.collateralTypesData);
@@ -444,6 +445,13 @@ const Home: NextPage = () => {
       softReset();
     }
   }
+
+  // Cycle the first page render to allow styles to load
+  React.useEffect(() => {
+    setInitialPageLoad(false);
+  }, []);
+
+  if (initialPageLoad) return null;
 
   return (
     <div>

--- a/src/components/CollateralTypesTable.tsx
+++ b/src/components/CollateralTypesTable.tsx
@@ -87,7 +87,7 @@ export const CollateralTypesTable = (props: CollateralTypesTableProps) => {
                   <Table.Cell>{`${floor2(wadToDec(earnableRateAnnulized.mul(100)))}% (${floor2(wadToDec(earnableRate.mul(100)))}%)`}</Table.Cell>
                   <Table.Cell>{`${floor2(wadToDec(borrowRateAnnualized.mul(100)))}% (${floor2(wadToDec(borrowRate.mul(100)))}%)`}</Table.Cell>
                   <Table.Cell>{`${floor2(Number(wadToDec(depositedCollateral))).toLocaleString()} ${symbol}`}</Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell css={{'& span': {width: '100%'}}}>
                     <Badge isSquared color={new Date() < maturityFormatted ? 'success' : 'error'} variant='flat' >
                       {formatUnixTimestamp(maturity)}, ({daysUntilMaturity} days)
                     </Badge>

--- a/src/components/CollateralTypesTable.tsx
+++ b/src/components/CollateralTypesTable.tsx
@@ -39,7 +39,7 @@ export const CollateralTypesTable = (props: CollateralTypesTableProps) => {
       <Text h2>Create Position</Text>
       <Table
         aria-label='Collateral Types'
-        css={{ height: 'auto', minWidth: '100%' }}
+        css={{ height: 'auto', minWidth: '1088px' }}
         selectionMode='single'
         selectedKeys={'1'}
         onSelectionChange={(selected) => props.onSelectCollateralType(Object.values(selected)[0])}

--- a/src/components/PositionsTable.tsx
+++ b/src/components/PositionsTable.tsx
@@ -50,7 +50,7 @@ export const PositionsTable = (props: PositionsTableProps) => {
       <Text h2>Positions</Text>
       <Table
         aria-label='Positions'
-        css={{ height: 'auto', minWidth: '100%' }}
+        css={{ height: 'auto', minWidth: '1088px' }}
         selectionMode='single'
         selectedKeys={'1'}
         onSelectionChange={(selected) =>

--- a/src/components/PositionsTable.tsx
+++ b/src/components/PositionsTable.tsx
@@ -144,7 +144,7 @@ export const PositionsTable = (props: PositionsTableProps) => {
                       ? '∞' : `${floor2(wadToDec(collRatio.mul(100)))}%`
                     }
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell css={{'& span': {width: '100%'}}}>
                     <Badge isSquared color={new Date() < maturityFormatted ? 'success' : 'error'} variant='flat' >
                       {formatUnixTimestamp(maturity)}, ({daysUntilMaturity} days)
                     </Badge>


### PR DESCRIPTION
Fixes #20 - Fixes min width by first setting a lg breakpoint. This allows the margins to collapse when < 1280 so smaller screens will get the full width. This allowed me to set a smaller min-width for the tables because of the margin breakpoint.

Fixes #40 - Overrides the style for a span in the table cell to have the full width. The next ui badge css overrides go into a child component for some reason. 

Fixes #50 - To fix the flash of unstyled content, I cycle the first page render. This seems to allow the server side rendering enough time to apply the styles.[In nextjs 13 there is a loading ui component that could have been useful](https://beta.nextjs.org/docs/routing/loading-ui). Also I believe this issue we were experiencing is a bug in the nextui implementation for css overrides. If we move to material UI, they have utilities in place for their styled components to prevent the flash of unstyled content.