### PR TITLE
Fix parameter order for redeem method

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -588,8 +588,8 @@ export const buildSellCollateralAndModifyDebtArgs = (
 export const buildRedeemCollateralAndModifyDebtArgs = (
   fiat: any,
   user: string,
-  collateralTypeData: any,
   proxies: any[],
+  collateralTypeData: any,
   deltaCollateral: BigNumber,
   deltaDebt: BigNumber,
   position: any


### PR DESCRIPTION
Fixes the parameter order for this redeem method builder.

The usage shows proxies should come before collateralTypeData. This change aligns with the other action methods parameter order.

```
      const args = userActions.buildRedeemCollateralAndModifyDebtArgs(
        fiat, user, proxies, collateralType, deltaCollateral, deltaDebt, position
      );
```